### PR TITLE
Update URL and description for redux-bootstrap

### DIFF
--- a/project-scaffolding.md
+++ b/project-scaffolding.md
@@ -21,8 +21,8 @@
   Modular Redux bootstrap with asynchronous side-effects.  Minimal Framework using Redux to develop modularized universal (backend and frontend) applications, based on functional programming paradigms and friends such as Map and Reduce, Immutability and Reactive programming.
   
 - **redux-bootstrap**  
-  https://github.com/remojansen/redux-bootstrap  
-  Bootstrapping function for Redux applications. Redux bootstrap does not generate files for you. It is not a project template or project scaffolding tool and it is not related with Bootstrap (responsive web apps framework).  This library handles most of the common application initialization/bootstrapping that takes place every time you create a new Redux project.
+  https://github.com/redux-bootstrap/redux-bootstrap  
+  A `bootstrap()` function for initializing Redux applications. This module works by exporting a `bootstrap` function you can call in your project. It does not generate files for you – it is not a project template or project scaffolding tool. This library handles most of the common application initialization/bootstrapping that takes place every time you create a new Redux project.
   
 - **mikey**  
   https://github.com/Mikeysax/mikey  


### PR DESCRIPTION
The [current URL](https://github.com/remojansen/redux-bootstrap) redirects to this [new URL](https://github.com/redux-bootstrap/redux-bootstrap). And the description in redux-bootstrap’s README was just updated.