### PR TITLE
Add redux-generators and Black Pixel Redux Handbook

### DIFF
--- a/other-resources.md
+++ b/other-resources.md
@@ -28,6 +28,10 @@
 - **Canonical Reducer Composition**  
   https://github.com/gajus/canonical-reducer-composition  
   A spec for organizing reducers around domains.
+
+- **Black Pixel Redux Handbook**  
+  http://bpxl-labs.github.io/redux-handbook/  
+  A guideline for structuring scalable Redux applications. It encourages conventions and best practices adopted at Black Pixel.
   
 - **redux-convention**  
   https://github.com/gajus/redux-convention  

--- a/project-scaffolding.md
+++ b/project-scaffolding.md
@@ -1,5 +1,9 @@
 ### Project Scaffolding and CLIs
 
+- **redux-generators**  
+  https://github.com/bpxl-labs/redux-generators
+  Redux Generators is a lightweight, opinionated CLI that helps scaffold a scalable approach to Redux.
+
 - **redux-thunk-scaffolding**  
   https://github.com/jmakeig/redux-thunk-scaffolding  
   Generate scaffolding for asynchronous Redux actions, in the style of redux-thunk middleware.


### PR DESCRIPTION
This PR includes two different links.

The first is a scaffolding tool called [redux-generators](https://github.com/bpxl-labs/redux-generators) that speeds up the development of structured, scalable Redux applications. It implements some best practices laid out in the [Black Pixel Redux Handbook](http://bpxl-labs.github.io/redux-handbook/).

The second is the [Black Pixel Redux Handbook](http://bpxl-labs.github.io/redux-handbook/) which lays out some best practices, tips, and guidelines for creating a scalable Redux application.