### PR TITLE
Added Edux to the action-reducer-generators.md

### DIFF
--- a/action-reducer-generators.md
+++ b/action-reducer-generators.md
@@ -155,7 +155,13 @@
 - **redux-scc**  
   https://github.com/TheComfyChair/redux-scc  
   Redux store chunk creator.  It takes a defined structure and uses a set of 'behaviors' (a small collection of ways that a reducer can be updated) to create a set of actions and reducer responses that are each linked by a unique string. A set of action generators, selectors, and reducers are then returned.
-  
+
+- **Edux**  
+  https://github.com/dogada/edux  
+  Edux is DRY version of Redux (no constants and switches, actions and reducers are generated from single source). Edux process actions with O(1) speed instead of Redux's O(N) where N is number of reducers. Edux and Redux works well together. Redux state is single source of truth on data level. Edux changes are single source of truth on logic level.  
+
+ 
+ 
 
 #### Network Requests and APIs
 


### PR DESCRIPTION
# Formatting

Please follow the existing formatting for each entry.  In order to get newlines without paragraph breaks, each entry should have two spaces at the end of the line after both the URL and the title.  Also, two-space indents before the URL and the description.  Example:

```markdown
- **Link Title**<space><space>  
<space><space>http://example.com<space><space>  
<space><space>Link description here
```

Result:

- **Link Title**  
  http://example.com  
  Link description here
  
Please do _not_ strip whitespace for existing entries!
