### PR TITLE
Change redux-data-structures URL

### DIFF
--- a/reducers.md
+++ b/reducers.md
@@ -449,8 +449,8 @@
   https://github.com/oreshinya/initializable-reducer  
   Initializing reducers action and associated higher order reducer for redux.
   
-- **redux-data-structure**  
-  https://redux-data-structures.js.org/  
+- **redux-data-structures**  
+  https://github.com/adrienjt/redux-data-structures  
   Redux Data Structures is a library of higher-order functions ("reducer makers").  Reducer makers help create common reducers like counters, maps, lists (queues, stacks), sets, etc. Most application states can be built by combining a handful of these standardized building blocks.
   
 - **common-reducers**  

--- a/reducers.md
+++ b/reducers.md
@@ -450,7 +450,7 @@
   Initializing reducers action and associated higher order reducer for redux.
   
 - **redux-data-structure**  
-  https://github.com/PacificCodology/redux-data-structures  
+  https://redux-data-structures.js.org/  
   Redux Data Structures is a library of higher-order functions ("reducer makers").  Reducer makers help create common reducers like counters, maps, lists (queues, stacks), sets, etc. Most application states can be built by combining a handful of these standardized building blocks.
   
 - **common-reducers**  
@@ -554,7 +554,7 @@
   
 - **redux-rack**  
   https://github.com/evanrs/redux-rack  
-  Treat Redux like a rack — mount reducers like components 
+  Treat Redux like a rack Â— mount reducers like components 
   
 - **reducer-generator**  
   https://github.com/Dash-OS/reducer-generator-array-map  


### PR DESCRIPTION
Hi! I moved redux-data-structures from my GitHub organization PacificCodology back to my personal space adrienjt. I wanted to start a blog named PacificCodology or Codology but it's still in the works, so it just made more sense to host under adrienjt. I also created a js.org subdomain for redux-data-structures, which hosts the Readme using GitHub pages.

So, although the current link still works (it redirects to adrienjt/redux-data-structures), I'd like to either change it to https://redux-data-structures.js.org/ (my first choice) or https://github.com/adrienjt/redux-data-structures (if you prefer GitHub links).