### PR TITLE
Added combineCrossSliceReducers.

### DIFF
--- a/reducers.md
+++ b/reducers.md
@@ -123,6 +123,10 @@
   https://github.com/ryo33/combine-section-reducers  
   Section reducers is the same as reducers but it requires the third argument to get the entire state.  (sectionState, action, state) => newSectionState
   
+- **combineCrossSliceReducers**  
+  https://github.com/visusnet/combine-cross-slice-reducers  
+  Similar to `combineSectionReducers` but introduces stages which gives lower-ranking reducers access to the global state that results from higher-ranking reducers.
+  
 - **Redux Conditional**  
   https://github.com/ypxing/redux-conditional  
   Conditionally apply actions to Redux reducers to make sharing reducers easy.


### PR DESCRIPTION
combineCrossSliceReducers is very similar to combineSectionReducers but with a small twist:

While combineSectionReducers passes the original ``entireState`` as a third parameter to each reducer, combineCrossSliceReducers passes the updated state which is the result of all previous reducers.

Example:
```javascript
const rootReducer = combineSectionReducers({
    increment: (state = 0, action) => state + action.value,
    mirrorIncrement: (state = 0, action, entireState) => entireState.increment
});

rootReducer(undefined, {type: 'foobar', value: 1});
// {
//     increment: 1,
//     mirrorIncrement: 0
// }
```
but with combineCrossSliceReducers:
```javascript
const stage1Reducers = {
    increment: (state = 0, action) => state + action.value
};
const stage2Reducers = {
    mirrorIncrement: (state = 0, action, entireState) => entireState.increment
};
const rootReducer = combineCrossSliceReducers(stage1Reducers, stage2Reducers);

rootReducer(undefined, {type: 'foobar', value: 1});
// {
//     increment: 1,
//     mirrorIncrement: 1
// }
```