### PR TITLE
Fix a lost link (power-assign -> sp2)

### DIFF
--- a/immutable-data.md
+++ b/immutable-data.md
@@ -117,9 +117,9 @@ A collection of functions to perform immutable operations on plain JavaScript ob
   https://github.com/engineforce/ImmutableAssign  
   Lightweight immutable helper that allows you to continue working with POJO (Plain Old JavaScript Object), and supports full TypeScript type checking
 
-- **power-assign**  
-  https://github.com/phenyl-js/phenyl/tree/master/modules/power-assign
-  Immutable updater of POJO using MongoDB's operator, easier access to nested values.
+- **sp2**  
+  https://github.com/phenyl-js/sp2
+  Immutable updater that allows you to access nested values with Typescript autocompletion.
 
 - **immutable-helpers**  
   https://github.com/zammer/immutable-helpers  


### PR DESCRIPTION
I fix a lost link to a repository [phenyl-js/sp2](https://github.com/phenyl-js/sp2). It was renamed and moved to new repository.

Thank you for maintaining this links !!