### PR TITLE
Removed duplicate entry for redux-undo-redo

### DIFF
--- a/use-cases.md
+++ b/use-cases.md
@@ -471,10 +471,6 @@
   https://github.com/morkl/redux-branchable  
   A simple reducer enhancer for redux which enables branching time travel. All actions are saved, time travel is possible and encouraged, and any actions dispatched from a historic state result in a new branch being created.
   
-- **redux-undo-redo**  
-  https://github.com/welldone-software/redux-undo-redo  
-  Prebuilt undo-redo handling reducer and middleware.  Define which actions are undoable and how to revert them.
-  
 - **Redux-Queue**  
   https://github.com/JBlaak/Redux-Queue  
   Higher order reducer so you don't have to worry about order of arrival of the results of your actions.


### PR DESCRIPTION
<!--
# Formatting

Please follow the existing formatting for each entry.  In order to get newlines without paragraph breaks, each entry should have two spaces at the end of the line after both the URL and the title.  Also, two-space indents before the URL and the description.  Example:

```markdown
- **Link Title**<space><space>  
<space><space>http://example.com<space><space>  
<space><space>Link description here
```

Result:

- **Link Title**  
  http://example.com  
  Link description here
  
Please do _not_ strip whitespace for existing entries!
-->

The link at line 461 links to the same repo as line 474 in use-cases.md.

I removed the second one because it seems the repo was moved:

`Welldone-Software/redux-undo-redo` -> `PowToon/redux-undo-redo`