### PR TITLE
Prune dead links 2020-01-24

### DIFF
--- a/action-reducer-generators.md
+++ b/action-reducer-generators.md
@@ -27,10 +27,6 @@
   https://github.com/BurntCaramel/flambeau  
   Opinionated Redux additions: declarative, pleasant action creators, reducer encapsulation, async support
   
-- **redux-dispatcher-reducer**  
-  https://github.com/stevenla/redux-dispatcher-reducer  
-  Reduce boilerplate in your redux code by using auto-generated action creators that automatically map to reducers
-
 - **dead-simple-redux-helper**  
   https://github.com/armed/dead-simple-redux-helper  
   Dead simple redux helper for actions and reducers
@@ -71,10 +67,6 @@
   https://github.com/Xananax/actionsreducer  
   Simplifies the creation of actions, state, and reducers, and the creation of async actions. Return values are automatically re-assigned to state at the right location, no need for reducers composition.
   
-- **redux-standard-actions**  
-  https://github.com/yangmillstheory/redux-standard-actions  
-  Flux Standard Action utilities for Redux.
-  
 - **redux-factories**  
   https://github.com/zxdong262/redux-factories  
   A factory lib to produce redux constants and reducers of certain format.
@@ -104,10 +96,6 @@
   https://github.com/trabe/fredux-api-utils  
   Fredux is a utility library to make the development process of redux applications faster and easier. Fredux provides some conventions and tools to create actions which follows some standard structure, create asynchronous actions, and handle pending promise actions when the context of the application changes like in a page navigation.
   
-- **redux-routine**  
-  https://github.com/ezhikov/redux-routine  
-  Set of small utils for creation of basic redux routines as collection reducer (uses Map for collection state), item reducer, actionCreators and basic action types (ADD, REMOVE, CHANGE)
-  
 - **f1-redux-utils**  
   https://github.com/nicocrm/f1-redux-utils  
   Utility functions for generating actions, creating containers that dispatch actions on mount, and creating reducers that handle prefixed actions
@@ -119,10 +107,6 @@
 - **redux-seeds**  
   https://github.com/quinnnned/redux-seeds  
   Factories for Generating Common Redux State Trees
-  
-- **redux-reducer**  
-  https://github.com/webdeveloperpr/redux-reducer  
-  Generates prefixed actions and reducers
   
 - **Redeclare**  
   https://github.com/modernserf/redeclare  
@@ -204,10 +188,6 @@
   https://github.com/loklaan/redux-motive  
   Simplify writing action creators, reducers and effects - without breaking redux. 
   
-- **redux-utils**  
-  https://github.com/graftss/redux-utils  
-  A collection of utilities for generating actions, reducers, and tests
-  
 - **sleipnir**  
   https://github.com/benoneal/sleipnir  
   A convenience interface for Redux, to remove boilerplate and provide sensible asynchronous action handling.
@@ -231,10 +211,6 @@
 - **redux-async-action-reducer**  
   https://github.com/neolivz/redux-async-action-reducer  
   Simple redux action creation and reducer wrapper that makes creating and handling asynchronous and synchronous wrapper easier. It's completely written with type safety in mind, with typescript.
-  
-- **reduxec**  
-  https://github.com/Noviel/reduxec  
-  Create reusable, targeted actions and reducers for Redux
   
 - **redux-namespaces**  
   https://github.com/9technology/redux-namespaces  
@@ -263,10 +239,6 @@
 - **trampss-redux-factory**  
   https://github.com/Trampss/trampss-redux-factory  
   Factory of Redux reducers and their associated actions and selectors - creates generic reducers, actions and selectors in two lines.
-  
-- **redux-composable**  
-  https://github.com/aakashns/redux-composable  
-  Utilities and higher order functions for reducer composition and reuse
   
 - **redux-less**  
   https://github.com/lovetingyuan/redux-less  
@@ -299,14 +271,6 @@
 - **redux-act-array-async**  
   https://github.com/jiang-12196/redux-act-array-async  
   Create async multi actions and reducers based on redux-act
-  
-- **atomic-redux**  
-  https://github.com/brietsparks/atomic-redux  
-  Building blocks for composing normalized collection-based state  
-  
-- **catalyst-redux**  
-  https://github.com/friendsoftheweb/catalyst-redux  
-  Allows generating action creators/reducers as "operations" for sync and async behavior, and composition of operations into larger "modules".  Also provides "resource modules" for interacting with a JSON API.
   
 - **redux-processor**  
   https://github.com/nicholasrq/redux-processor  
@@ -359,17 +323,9 @@
   https://github.com/rjbma/redux-promise-reducer  
   Easily integrate with redux-promise-middleware.  Create actions with createPromiseAction, which are handled by the middleware, which dispatches new actions when the status of the promise changes.
   
-- **redux-utils**  
-  https://github.com/newtack/redux-utils  
-  Redux-utils makes it easy to combine redux and immutableJS as well as make api calls using FSA conventions.
-
 - **redux-async-collection**  
   https://github.com/QubitProducts/redux-async-collection  
   Creates a reducer, immutable state and actions for an async collection
-  
-- **redux-reqhelper**  
-  https://github.com/ophite/redux-reqhelper  
-  Helper for processing requests in redux (work with actions, reducers, selectors)
   
 - **redux-rest-resource**  
   https://github.com/mgcrea/redux-rest-resource  
@@ -415,10 +371,6 @@
   https://github.com/StickyCube/redux-fetch-resource  
   redux-fetch-resource is an attempt at a complete solution for making api requests in react/redux applications.
   
-- **redux-restapi**  
-  https://github.com/ghalex/redux-restapi  
-  redux-restapi is an utility for integrating a REST api with Redux. It helps you, to easily integrate your calls to a REST api with your store. It generates actions and reducer for making the calls to the server and can easly be combined with your actions.
-  
 - **magic-redux-generator**  
   https://github.com/luisfuertes/magic-redux-generator  
   Utils to generate types and action creators for various network requests
@@ -432,7 +384,7 @@
   Thunk actions and reducers for handling data from a REST API
   
 - **redux-easy-async**  
-  https://github.com/evanhobbs/redux-easy-async#motivation  
+  https://github.com/evanhobbs/redux-easy-async  
   Redux Easy Async makes handling asynchronous actions, such as API requests, simple, reliable, and powerful.
   
 - **redux-simple-api**  

--- a/actions.md
+++ b/actions.md
@@ -120,10 +120,6 @@
   https://github.com/tbranyen/redux-create-action-types  
   Helps you create Redux action types, safely & easily.  Helps define action types without duplication and provides some validation.
   
-- **redux-nested-actions**  
-  https://github.com/yangmillstheory/redux-nested-actions  
-  Namespacing utilities for redux-actions.
-  
 - **redux-define**  
   https://github.com/smeijer/redux-define  
   Define action constants for Redux
@@ -318,10 +314,6 @@
 - **type-stash**  
   https://github.com/DaneSirois/type-stash  
   Redux type-management library.  Removes the need for a dedicated "types" file.
-  
-- **seashell-redux**  
-  https://github.com/heineiuo/seashell-redux  
-  A simple way to write functions with context dependencies without context parameter
   
 - **redux-nested-bind-actions**  
   https://github.com/Jc160/redux-nested-bind-actions  

--- a/apps-and-examples.md
+++ b/apps-and-examples.md
@@ -23,7 +23,6 @@ Note: This is not a comprehensive list of all projects using Redux, just a selec
   
 - **Redux Saga Examples**  
   https://github.com/kuy/redux-saga-examples  
-  http://kuy.github.io/redux-saga-examples/  
   A set of examples demonstrating usage of redux-saga (autocomplete, throttle, start-stop, backend integration)
   
 - **Lifegame Redux**  
@@ -50,10 +49,6 @@ Note: This is not a comprehensive list of all projects using Redux, just a selec
   https://github.com/GoTeamEpsilon/angular-to-react-redux  
   An educational resource for Angular v1 experts that are looking to learn React/Redux. A contrived sample application for managing basic patient information is provided using both technologies' best practices.
   
-- **react-stage-mgmt**  
-  https://github.com/pixelingene/react-state-mgmt  
-  A repo demonstrating various ways to build a login form and signup flow, using Redux+thunks, Redux+sagas, Redux+observables, and MobX
-  
 - **RealWorld: React/Redux Modular**  
   https://github.com/j-hannes/realworld-react-redux-modular  
   Another React/Redux implementation of the RealWorld example, demonstrating a modular/feature-based structure
@@ -71,7 +66,7 @@ Note: This is not a comprehensive list of all projects using Redux, just a selec
   An adaptation of the "Yelp Clone" app by FullStackReact.  It extends the original by using Redux and Redux Saga instead of local state, as well as React Router v4, styled-components, and other modern standards.  Based on the React-Boilerplate starter kit.
   
 - **hacker-news-resolve**  
-  https://github.com/reimagined/hacker-news-resolve  
+  https://github.com/reimagined/resolve/tree/master/examples/hacker-news  
   A Hacker News clone, built using the Resolve library that abstracts over React and Redux
   
 
@@ -121,7 +116,6 @@ Note: This is not a comprehensive list of all projects using Redux, just a selec
   https://github.com/mozilla/tofino  
   An experimental browser prototype, investigating new ideas and interactions.
   
-  
 - **Guild Wars 2 Armory**  
   https://github.com/madou/armory-react  
   Allows GW2 players to share account, character, and guild information.
@@ -147,7 +141,7 @@ Note: This is not a comprehensive list of all projects using Redux, just a selec
   New user interface for Neos CMS built with React and Redux. This is an ongoing project, and it is open to new contributors.
 
 - **CarteJaune**  
-  https://github.com/nikgraf/CarteJaune 
+  https://github.com/nikgraf/CarteJaune  
   A React Native/Redux (+Saga) application to keep track of your vaccinations
 
 - **HyperTerm**  
@@ -157,10 +151,6 @@ Note: This is not a comprehensive list of all projects using Redux, just a selec
 - **Phoenix Trello**  
   https://github.com/bigardone/phoenix-trello  
   Trello tribute done in Elixir, Phoenix Framework, React and Redux.
-  
-- **JSchematic**  
-  https://github.com/nicksenger/JSchematic  
-  JSchematic is a React-Redux application for drawing molecules and chemical reactions
   
 - **io-808**  
   https://github.com/vincentriemer/io-808  
@@ -172,7 +162,6 @@ Note: This is not a comprehensive list of all projects using Redux, just a selec
   
 - **Linode Manager**  
   https://github.com/Linode/manager  
-  https://engineering.linode.com/2016/05/16/Announcing-the-new-open-source-manager.html  
   Linode's new account management application
   
 - **Boostnote**  
@@ -239,10 +228,6 @@ Note: This is not a comprehensive list of all projects using Redux, just a selec
   https://github.com/buckyroberts/Vataxia-Frontend  
   Vataxia is an open source Reddit-like social network written in React and Redux.
   
-- **Easy Workout Log**  
-  https://github.com/victorparmar/easy-workout-log  
-  The front-end for the fitness tracking application https://ewolo.fitness .
-  
 - **Asteredux**  
   https://github.com/funkjunky/reduxgame  
   An Asteroids game with friction and terminal velocity. Built with Redux and a canvas.
@@ -304,17 +289,9 @@ Note: This is not a comprehensive list of all projects using Redux, just a selec
   https://github.com/nteract/nteract  
   A desktop application for running Jupyter notebooks
    
- - **react-flow-diagrams**  
-   https://github.com/rmfisher/react-flow-diagrams  
-   A drag-and-drop flow diagram builder
-   
 - **oni**  
   https://github.com/onivim/oni  
   Oni is a new kind of editor, focused on maximizing productivity - combining modal editing with features you expect in modern editors. Oni is built with neovim, and inspired by VSCode, Atom, LightTable, and Emacs
-  
-- **redux-game**  
-  https://github.com/osofour/redux-game  
-  Exploration of 2D WebGL rendering/physics with a Redux-based architecture.
   
 - **posthumus**  
   https://github.com/praghus/posthumus  
@@ -352,10 +329,6 @@ Note: This is not a comprehensive list of all projects using Redux, just a selec
 
 #### Redux Usage Stories
 
-- **Twitter: mobile.twitter.com**  
-  https://twitter.com/necolas/status/727538799966715904  
-  "Thanks for Redux. When we adopted it we saw big improvements in performance, testing, and code comprehension."
-  
 - **Lystable: Real World Redux**  
   https://speakerdeck.com/chrisui/real-world-redux  
   Explores the real world experiences of using Redux everyday within a rapidly scaling team and product.

--- a/component-data-fetching-preloading.md
+++ b/component-data-fetching-preloading.md
@@ -181,10 +181,6 @@
   https://github.com/reducks/redux-universal  
   A Redux store enhancer taking care of promise resolution for building universal apps. 
   
-- **universal-redux-thunk**  
-  https://github.com/tom-drake/universal-redux-thunk  
-  A Redux store enhancer taking care of promise resolution for building universal apps.  (Fork of redux-universal)
-  
 - **react-graphql-redux**  
   https://github.com/youknowriad/react-graphql-redux  
   This library allows you to use GraphQL to query your Redux store

--- a/component-state.md
+++ b/component-state.md
@@ -148,10 +148,6 @@
   https://github.com/molefrog/redux-actuator  
   Trigger events inside components by reacting on pure state changes. Actuator keeps you from writing component lifecycle hooks boilerplate code by providing declarative API.
   
-- **react-redux-sub-app**  
-  https://github.com/rtkhanas/react-redux-sub-app  
-  A small component to allow defining Redux sub-apps within a component tree
-  
 - **react-redux-combine-components**  
   https://github.com/simlrh/react-redux-combine-components  
   With React Redux Combine Components you can assign components to different properties of the state tree the same way you do with reducers. This aids reusability, as components need to know nothing about global state, and improves performance as they are only rerendered on change to their substree, instead of the global state.
@@ -168,18 +164,10 @@
   https://github.com/salsita/prism  
   React / Redux action composition made simple, using the action wrapping approach from Elm. (Formerly Redux-Elm)
   
-- **redux-scope-helpers**  
-  https://github.com/georgeawwad/redux-scope-helpers  
-  Functions for generating scoped action creators and reducers
-  
 - **redux-atom**
   https://github.com/bulicmatko/redux-atom  
   https://github.com/bulicmatko/react-redux-atom  
   Small utilities to generate encapsulated Redux logic and connected React components
-  
-- **with-component-state**  
-  https://github.com/chee/with-component-state  
-  Higher order component that will automatically create state for your redux components, and give you the prop componentState as well as the prop setState which works like this.setState on class components.
   
 - **redux-local-state**  
   https://github.com/t-benze/redux-local-state  
@@ -253,10 +241,6 @@
   https://github.com/Bandwidth/redux-facet  
   Scale redux applications more easily. Reuse behaviors, channel actions, and associate activity with component origins. 
   
-- **redux-call**  
-  https://github.com/Kontsedal/redux-call  
-  A simple util to add the ability to execute React component methods via Redux. It can be useful when you need to be able to conrtol components from any part of your app.
-  
 - **redux-pagestate**  
   https://github.com/etalisoft/redux-pagestate  
   redux-pagestate works with React Redux to enable a 'page' component in React to use Redux to store all of its state.
@@ -299,10 +283,6 @@
 - **Reduction Sauce**  
   https://github.com/ericwooley/reduction-sauce  
   Simple key value reducers without boilerplate
-  
-- **redux-values**  
-  https://github.com/alexesDev/redux-values  
-  Simple key-value storage for Redux
   
 - **react-redux-private-props**  
   https://github.com/dylanonelson/react-redux-private-props  
@@ -364,10 +344,6 @@
   https://github.com/brianneisler/duxtape  
   Module and util framework for redux.  Introduces an abstract module construct for redux. Allows modularization of functionality and easy plug and play workflow, with a hook system for extending the functionality of redux
   
-- **redux-segments**  
-  https://github.com/dennisgulich/redux-segments  
-  Library for writing reusable redux modules.  Writing reducers, action creators and mapping everything to the UI is tedious and time consuming, redux-segments solves this issue by breaking up the redux boilerplate into generic reusable modules.
-
 - **redux-stack**  
   https://github.com/jondot/redux-stack  
   A library that helps you build modular, structured, and cleaner redux apps.  Redux Stack introduces a concept of initializers. Small pieces of integration code, per library, that "declares" how it integrates. Redux Stack will mesh these together to create your personalized store builder.

--- a/devtools.md
+++ b/devtools.md
@@ -170,10 +170,6 @@
   https://github.com/sergiodxa/redux-catch  
   Error catcher middleware for Redux reducers and middlewares.
   
-- **realtime-redux-logger**  
-  https://github.com/dbslone/realtime-redux-logger  
-  Log Redux Actions in realtime to an electron app for separate browser viewing
-  
 - **redux-bug-reporter**  
   https://github.com/dtschust/redux-bug-reporter  
   A bug reporter and bug playback tool for redux.  Includes easy bug reporting, logging of state, redaction of sensitive information, easy bug playback, and more.
@@ -205,10 +201,6 @@
 - **redux-bugsnag**  
   https://github.com/restorando/redux-bugsnag  
   Redux middleware that logs to Bugsnag
-  
-- **replicator**  
-  https://github.com/nrdobie/replicator  
-  Record and replay user actions from Redux.
   
 - **redux-log-diff**  
   https://github.com/Bebersohl/redux-log-diff  
@@ -347,10 +339,6 @@ Also see the [Mutation Detection](#mutation-detection) section just above.
   https://github.com/mkamakura/redux-validation  
   Validate action properties
   
-- **action-validate**  
-  https://github.com/chbinghu/action-validate  
-  Validate that actions match the Flux Standard Action definition
-  
 - **redux-validate-actions**  
   https://github.com/asn007/redux-validate-actions  
   A small tool to automatically validate redux actions based on a predicate and log wrongly formatted actions into console 
@@ -358,10 +346,6 @@ Also see the [Mutation Detection](#mutation-detection) section just above.
 - **redux-validator**  
   https://github.com/MaxLi1994/redux-validator  
   Action parameter validator middleware for redux
-  
-- **redux-tsa**  
-  https://github.com/contrarian/redux-tsa  
-  Async friendly validation middleware for Redux 
   
 - **redux-payload-validator**  
   https://github.com/tomoyuki-tanaka/redux-payload-validator  
@@ -377,10 +361,6 @@ Also see the [Mutation Detection](#mutation-detection) section just above.
 - **React Render Visualizer**  
   https://github.com/redsunsoft/react-render-visualizer  
   A component mixin that overlays a tooltip indicating when a component has re-rendered and why, as well as animating the component's outline.
-
-- **react-transform-render-visualizer**  
-  https://github.com/spredfast/react-transform-render-visualizer  
-  A react-transform version of the render visualizer.  Transforms *all* React components by default, but also offers a second transform that can be used to only modify components with a `static rerenderViz = true` attribute on the component class.
 
 - **"WhyDidYouUpdateMixin"**  
   http://benchling.engineering/deep-dive-react-perf-debugging/  

--- a/entity-collection-management.md
+++ b/entity-collection-management.md
@@ -159,10 +159,6 @@
   https://github.com/AlexHenkel/reduxsauce-crud  
   Adaptation of the reduxsauce utils to add CRUD functionality
   
-- **collectionReducer**  
-  https://github.com/volodymyrl/collectionReducer  
-  A small action/reducer creator for CRUD ops by ID
-  
 - **standard-redux-shape**  
   https://github.com/ecomfe/standard-redux-shape  
   A tiny utility library to help you manage an optimized redux store shape.
@@ -267,7 +263,7 @@
   
 - **resourceful-redux**  
   https://github.com/jmeas/resourceful-redux  
-  A system for managing 'resources' – data that is persisted to remote servers.
+  A system for managing 'resources': data that is persisted to remote servers.
   
 - **redux-query**  
   https://github.com/amplitude/redux-query  
@@ -292,10 +288,6 @@
 - **redux-resx**  
   https://github.com/fixate/redux-resx  
   Yet another Redux action creators, a reducer and middleware for resource-based APIs.
-  
-- **redux-json-api-toolbox**  
-  https://github.com/rmarganti/redux-json-api-toolbox  
-  Redux middleware and helpers for working with JSON API standard server requests 
   
 - **redux-entities**  
   https://github.com/zebulonj/redux-entities  

--- a/forms.md
+++ b/forms.md
@@ -41,10 +41,6 @@
   https://github.com/calvinfroedge/react-redux-autobound-inputs  
   Two way data binding and edit / view states for selected input controls.  This project provides automatic data binding to redux store for some common inputs. The inputs include choices from react-bootstrap and react-widgets.
 
-- **redux-easy-forms**  
-  https://github.com/moarwick/redux-easy-forms  
-  REForms: A React-Redux forms library for the people!  Define your fields via a simple "schema" object.  REForms automatically flows your form data through Redux state. Use a friendly API to interact with your forms and data. Supply your own validation functions and error messages, sanitizers, filters. Use it with raw HTML inputs, React-Bootstrap, custom components.
-  
 - **redux-form-validation-helpers**  
   https://github.com/leiringer/redux-form-validation-helpers  
   A number of validation functions.
@@ -53,25 +49,13 @@
   https://github.com/kjessec/react-formagic  
   A react form binding that adapts to your code, not the other way around.  At the end of the day, react-formagic is just a HoC wrapper that translates props given to it into a set of enhanced props that'll make it easy to work with forms.
   
-- **luft**  
-  https://github.com/jdudek/luft  
-  Simple and flexible forms in React and Redux
-  
 - **React Redux Local Form**  
   https://github.com/jschr/react-redux-form-provider  
   React components for building forms with a local Redux store for managing state.
   
-- **asasalad**  
-  https://github.com/contrarian/asasalad  
-  Redux Form Validation Utility Designed to Work With Immutable.js 
-  
 - **simple-redux-form**  
   https://github.com/mihirsoni/simple-redux-form  
   A tiny alternative for Redux-Form
-  
-- **franklin**  
-  https://github.com/contrarian/franklin  
-  Franklin lets you build boilerplate-free Redux forms. 
   
 - **rform**  
   https://github.com/KonstantinKo/rform  
@@ -81,10 +65,6 @@
   https://github.com/wellguimaraes/react-formy  
   A light, simple and fast Higher Order Component to keep form state, inspired by redux-form.
 
-- **react-forms**  
-  https://github.com/luvago/react-forms  
-  Provides containers, helpers and reducers to work with Forms in React/Redux
-  
 - **onion-form**  
   https://github.com/blueberryapps/onion-form  
   React Redux form builder with great UX validations
@@ -100,10 +80,6 @@
 - **redux-pure-form**  
   https://github.com/max-mykhailenko/redux-pure-form  
   Redux actions for good performance and integration with your reducers
-  
-- **basquiat**  
-  https://github.com/contrarian/basquiat  
-  Another Redux form factory library, with handling for validation and fields
   
 - **redux-forms**  
   https://github.com/oreqizer/redux-forms  
@@ -168,10 +144,6 @@
 - **redux-reselect-validation**  
   https://github.com/ffossum/redux-reselect-validation  
   Actions, selectors, and reducers for helping manage form input validation.
-  
-- **controlled-form**  
-  https://github.com/bdmason/controlled-form  
-  A package for building forms in React & Redux. 
   
 - **redux-duck-form**  
   https://github.com/ivanwolf15/redux-duck-form  

--- a/immutable-data.md
+++ b/immutable-data.md
@@ -4,7 +4,7 @@
 #### Immutable Data Structures (Specialized)
 
 - **Immutable.js**  
-  https://facebook.github.io/immutable-js/  
+  https://immutable-js.github.io/immutable-js/  
   Fully-featured data structures library that uses advanced internal data storage to efficiently manage modified references.  Very widely used, but also rather complex.
 
 - **Mori**  
@@ -299,10 +299,6 @@ A collection of functions to perform immutable operations on plain JavaScript ob
 - **redux-seamless-immutable**  
   https://github.com/eadmundo/redux-seamless-immutable  
   Helpers for using seamless-immutable in Redux. Provides a compatible combineReducers and routerReducer (for use with react-router-redux).
-  
-- **mori-redux**  
-  https://github.com/dynn/mori-redux  
-  createReducer and combineReducers utilities that work with Mori structures
   
 - **redux-utils-immutable**  
   https://github.com/jcoreio/redux-utils-immutable  

--- a/library-integration.md
+++ b/library-integration.md
@@ -214,4 +214,4 @@
   
 - **glace**  
   https://github.com/Fordi/glace  
-  Glacé aspires to be a simple, fast, small, and elegant view layer for simple Redux-based apps. Its templates are entirely well-formed XML fragments and it outputs real DOM in real time.
+  GlacÃ© aspires to be a simple, fast, small, and elegant view layer for simple Redux-based apps. Its templates are entirely well-formed XML fragments and it outputs real DOM in real time.

--- a/middleware-async.md
+++ b/middleware-async.md
@@ -79,10 +79,6 @@
   https://github.com/themostaza/redux-pinky  
   Yet another Redux middleware for dispatching async actions.  A more "redux-vanilla" version of redux-pack.
   
-- **redux-promises-concluder**  
-  https://github.com/arashmilani/redux-promises-concluder  
-  A Redux middleware to keep track of active promises and notify when all resolved. Useful in server side rendering of single page applications. 
-  
 - **redux-p**  
   https://github.com/fedor/redux-p  
   redux-p middleware accepts action type in action.type and Promise in action.payload. It was made to made to replace redux-promise-middleware for React Native.
@@ -194,10 +190,6 @@
   https://github.com/rt2zz/redux-action-buffer  
   A middleware for redux that buffers all actions into a queue until a breaker condition is met, at which point the queue is released (i.e. actions are triggered).
   
-- **Quince**  
-  https://github.com/defact/quince  
-  Queueing middleware for Redux.
-  
 - **redux-throttle-actions**  
   https://github.com/pirosikick/redux-throttle-actions  
   A Redux middleware which throttles actions.
@@ -270,10 +262,6 @@
 - **redux-reqres**  
   https://github.com/Shotzoom/redux-reqres  
   Request response synchronization middleware. Syncronization should be used when multiple async actions may be dispatched to fetch data, but only the last response should be serviced such as type aheads and search filtering.
-  
-- **redux-action-trigger**  
-  https://github.com/Metnew/redux-action-trigger  
-  Mark action which you want to trigger after it will be dispatched, then after action has been triggered, it will be processed by your function and another action can be called.
   
 - **redux-offline-chain**  
   https://github.com/birgernass/redux-offline-chain  
@@ -397,10 +385,6 @@
 - **redux-client-middleware**  
   https://github.com/intactile/redux-client-middleware  
   A redux middleware handling async client actions.  Acts like a combination of redux-thunk and a promise middleware.
-  
-- **redux-roll**  
-  https://github.com/vgabor/redux-roll  
-  Redux-roll lets you dispatch chained functions and promises, and also allow you to mix-and-match functions and promises together. 
   
 - **redux-async-thunk**  
   https://github.com/kutlugsahin/redux-async-thunk  

--- a/middleware-network-requests.md
+++ b/middleware-network-requests.md
@@ -75,10 +75,6 @@
   https://github.com/agraboso/redux-api-middleware  
   Redux middleware for calling an API.
   
-- **rictus**  
-  https://github.com/defact/rictus  
-  Redux middleware for promise-based resource requests
-  
 - **redux-track-async**  
   https://github.com/lronhoj/redux-track-async  
   A lib for tracking pending async requests. Exposes middleware & a reducer
@@ -86,10 +82,6 @@
 - **multi-action-api-middleware**  
   https://github.com/gkosharov/multi-action-api-middleware  
   Redux api middleware for handling simultaneous asynchronous action dispatches (api calls).
-  
-- **redux-http-middleware**  
-  https://github.com/sky-uk/redux-http-middleware  
-  Make http requests by dispatching actions!  The goal of this module is to move the imperative handling of HTTP requests out of Redux applications. Instead HTTP requests are declared as actions and the success or failure of the request is dispatched as another action.
   
 - **redux-cached-api**  
   https://github.com/VerenigingCampusKabel/redux-cached-api  

--- a/middleware-sockets-adapters.md
+++ b/middleware-sockets-adapters.md
@@ -145,10 +145,6 @@
   https://github.com/adjohnson916/firedux  
   Firedux (fiery·ducks) wraps the Firebase JavaScript API to dispatch Redux actions that optimisically & immediately read/write to an in-memory subset of your data from Firebase, then asynchronously pull & push data in the background.  Also supports some authentication methods and actions.
 
-- **este-redux-firebase**  
-  https://github.com/este/este-redux-firebase  
-  Standalone module of Este's Firebase/Redux integration lib
-
 - **refire**  
   https://github.com/hoppula/refire  
   Declarative Firebase bindings for Redux and React.  Refire keeps your local Redux store in sync with selected Firebase paths. You can declaratively bind Firebase paths as Strings, Objects or Arrays.  You can also specify queries based on Redux state (e.g. currently logged in user or route parameter) and Refire will automatically subscribe and unsubscribe your bindings when state changes.

--- a/middleware.md
+++ b/middleware.md
@@ -93,10 +93,6 @@
   https://github.com/matthias-reis/redux-listener-middleware  
   A Redux middleware that acts as a general listener on actions that are dispatched to the Redux store, with rules for handling different actions.
   
-- **Redux Transform**  
-  https://github.com/contrarian/redux-transform  
-  Field transformation middleware for Redux. 
-  
 - **suber**  
   https://github.com/oskarhane/suber  
   A message bus compatible with Redux middlewares 
@@ -165,21 +161,13 @@
   https://github.com/jasonmorita/redux-intercept-action  
   Redux middleware to intercept and redirect FSA actions before they hit reducers.  Useful for handling actions coming in asyncronously from outside your app.
   
-- **redux-actionkit**  
-  https://github.com/WA9ACE/redux-actionkit  
-  A simple redux side-effect library that lets you add callbacks to be run when requested actions are dispatched
-  
 - **redux-pre-post-action-middleware**  
   https://github.com/slivcode/redux-pre-post-action-middleware  
   A middleware for executing user-provided callbacks before or after actions are passed onward.
   
-- **redux-provider**  
-  https://github.com/logaritmdev/redux-provider  
-  A middleware that abstract (mostly) async operations in its own layer. An action that is registered as a provider will be invoked first and the original action will be executed only when the provider dispatches the same action.
-  
 - **redux-iterator**  
   https://github.com/benjmac/redux-iterator  
-  Redux Iterator middleware is capable of receiving Sets, Maps, Arrays, Objects and Generators. Once the middleware is reached, they’re iterated over and the nested actions are dispatched to the Redux store.
+  Redux Iterator middleware is capable of receiving Sets, Maps, Arrays, Objects and Generators. Once the middleware is reached, they're iterated over and the nested actions are dispatched to the Redux store.
   
 - **redux-aop**  
   https://github.com/modernserf/redux-aop  
@@ -195,15 +183,11 @@
   
 - **redux-fries**  
   https://github.com/nicolasdelfino/redux-fries  
-  Greasy™ middleware for subscribing to actions and creating tasty side-effects in your code 
+  Greasy middleware for subscribing to actions and creating tasty side-effects in your code 
   
 - **redux-lifesaver**  
   https://github.com/americanexpress/redux-lifesaver  
   lifesaver is a middleware that keeps track of how many times actions of the same type are dispatched within a given period. If a single action type is dispatched more times than the allowed amount within a given period, subsequent dispatches of that action type will be blocked from the reducer for the same period. At the end of the period, the most recently attempted dispatch of that action type will go through.
-  
-- **signalbox**  
-  https://github.com/hnrysmth/signalbox  
-  Syntactical sugar for redux middlewares.  Define callbacks to run before or after specific actions.
   
 - **redux-mediator**  
   https://github.com/quadreex/redux-mediator  
@@ -220,10 +204,6 @@
 - **redux-action-middleware**  
   https://github.com/Gaya/redux-action-middleware  
   Redux middleware which allows the user to acts upon fired action types to the store.
-  
-- **redux-provider**  
-  https://github.com/logaritmdev/redux-provider  
-  A middleware that abstract (mostly) async operations in its own layer. An action that is registered as a provider will be invoked first and the original action will be executed only when the provider dispatches the same action.
   
 - **redux-listener**  
   https://github.com/kouhin/redux-listener  
@@ -402,17 +382,9 @@
   https://github.com/guillaumearm/redux-custom-middlewares  
   Middlewares inside your FSA actions
   
-- **rex-cookies**  
-  https://github.com/linear-bits/rex-cookies  
-  React Redux cookie middleware 
-  
 - **redux-middlewares**  
   https://github.com/ryo33/redux-middlewares  
   Utility functions to generate new middlewares.
-  
-- **redux-scraper**  
-  https://github.com/therewillbecode/redux-scraper  
-  Web scraping middleware for Redux using Cheerio and Axios 
   
 - **redux-dynamic-middlewares**  
   https://github.com/pofigizm/redux-dynamic-middlewares  
@@ -458,10 +430,6 @@
   https://github.com/Natasha08/redux-middleware-workers  
   A middleware to forward actions to webworkers.
   
-- **redux-reset-middleware**  
-  https://github.com/cadleo/redux-reset-middleware  
-  A redux plugin to reset the redux store
-
 - **redux-clipboard-copy**  
   https://github.com/weslleyaraujo/redux-clipboard-copy  
   Clipboard copy middleware for Redux using document.execCommand.

--- a/other-resources.md
+++ b/other-resources.md
@@ -4,7 +4,7 @@
 #### Redux Links
 
 - **Redux Docs: Ecosystem**  
-  http://redux.js.org/docs/introduction/Ecosystem.html  
+  https://redux.js.org/introduction/ecosystem  
   A vetted selection of useful links and libraries
 
 - **Awesome Redux**  

--- a/project-scaffolding.md
+++ b/project-scaffolding.md
@@ -79,7 +79,3 @@
 - **rrmw**  
   https://github.com/sedoyjan/rrmw  
   A CLI tool to help generate React-Redux modules from templates
-  
-- **reax-helpers**  
-  https://github.com/damianobarbati/reax-helpers  
-  Helper functions to set up a ready-to-use React+Redux app.  Creates a Redux store with support for thunks, promises, logging, and the Redux DevTools extension, plus store persistence.

--- a/reducers.md
+++ b/reducers.md
@@ -19,10 +19,6 @@
   https://github.com/nrn/create-reducer  
   Create a redux reducer from an object of action handling functions, keyed by the actions they handle. Has createReducer.compose(fns) helper function to combine multiple action handlers into a single action. 
   
-- **redux-map-reducers**  
-  https://github.com/zippyui/redux-map-reducers  
-  Redux reducer that maps over an object of action types.
-  
 - **reduxr-obj-reducer**  
   https://github.com/chrisdavies/reduxr-obj-reducer  
   A utility to create Redux reducers from simple objects.
@@ -111,10 +107,6 @@
   https://github.com/pcarden/fine-combine  
   Combines reducer collections, even when they have duplicate keys.
   
-- **stack-feature-store-redux**  
-  https://github.com/gp-technical/stack-feature-store-redux  
-  An alternative redux combineReducers function for use with feature package oriented applications
-  
 - **reduxerit**  
   https://github.com/jurgob/reduxerit  
   reduxerit is strongly influenced from redux-modifiers (https://github.com/calvinfroedge/redux-modifiers), It tries to simplify writing the redux reducer, but without using immutablejs.
@@ -162,10 +154,6 @@
 - **redux-sword**  
   https://github.com/somewind/redux-sword  
   Redux-Sword is a tool for Redux Reducer, which can make it automatically processed, so you can code less with it.
-  
-- **redux-cloneable**  
-  https://github.com/eliaslfox/redux-cloneable  
-  Small library for creating prefixed key/value reducers.
   
 - **redux-reducers**  
   https://github.com/casparrolfe/redux-reducers  
@@ -255,10 +243,6 @@
   https://github.com/jeremija/mixn  
   Mixes reducers in order. Allows easy extension of redux reducer functions. Tries each one until the state changes
   
-- **redux-cond**  
-  https://github.com/G1enY0ung/redux-cond  
-  Redux reducer with cond function, inspired by Clojure's cond
-  
 - **reducio**  
   https://github.com/asn007/reducio  
   Functional reducers for everybody 
@@ -338,10 +322,6 @@
 - **Redux-standard-reducer**  
   https://github.com/magicdawn/redux-standard-reducer  
   A redux reducer for standard actions that just need to merge data to state
-  
-- **combineMultiKeyReducers**  
-  https://gist.github.com/Heisenberg815/82ad6bd8dbf88b16df9af71d98b0b4db  
-  A custom reducer utility that will pass along specified slices of state to a reducer.
   
 - **redux-keto**  
   https://github.com/Airbitz/redux-keto  
@@ -539,10 +519,6 @@
   https://github.com/grifo/redux-reducer-maker  
   Prebuilt reducers for toggle values and request status
   
-- **atomic-redux**  
-  https://github.com/brietsparks/atomic-redux  
-  Building blocks for composing normalized collection-based state.  This library cuts down on boilerplate of writing reducers and action-creators for collection-based state. The goal is to make it easier to create and work with normalized state trees.
-  
 - **redux-flag-reducer**  
   https://github.com/DannyDelott/redux-flag-reducer  
   Create a reducer that returns true or false, "on" or "off", "loaded" or "loading", etc.  Makes it convenient to implement flags as reducers in your redux state tree. This can be handy for tracking all kinds of things from toggle-based UIs to the loading/loaded state of an external resource.
@@ -666,10 +642,6 @@
   https://github.com/kravchenkodev/redux-react-dynamic-store  
   Allows to register reducers dynamically through react container components to help solve code-splitting and complex state in large applications.
   
-- **sliced-redux**  
-  https://github.com/carnesen/sliced-redux  
-  A store enhancer that adds an `addSlice` method, allowing addition of slice reducers at runtime.
-  
 - **redux-injector**  
   https://github.com/randallknutson/redux-injector  
   Allows dynamically injecting reducers into a redux store at runtime
@@ -685,10 +657,6 @@
 - **redux-rack**  
   https://github.com/evanrs/redux-rack  
   Treat Redux like a rack  mount reducers like components 
-  
-- **redux-inject-reducer**  
-  https://github.com/umidbekkarimov/redux-inject-reducer  
-  Manage dynamic reducer injection and ejection in your redux app 
   
 - **redux-inject-reducer-and-saga**  
   https://github.com/marcelmokos/redux-inject-reducer-and-saga  
@@ -726,10 +694,6 @@
 - **react-component-chunk**  
   https://github.com/Droeftoeter/react-component-chunk  
   Library for making dynamic imports easy, with added support to make dynamically loaded Redux Reducers and Redux-Saga Sagas easy.
-  
-- **react-redux-async**  
-  https://github.com/sebastiendavid/react-redux-async  
-  Asynchronously load your module, then inject reducers and sagas.
   
 - **redux-extensible-store**  
   https://github.com/lundegaard/redux-extensible-store  

--- a/routing.md
+++ b/routing.md
@@ -64,10 +64,6 @@
   https://github.com/FormidableLabs/redux-little-router  
   A tiny router for Redux that lets the URL do the talking.
   
-- **redux-history-state**  
-  https://github.com/mortenolsendk/redux-history-state  
-  Redux state time traveling, optimized for pushState navigation 
-  
 - **redux-director**  
   https://github.com/mandeepbrar/redux-director  
   Redux bindings to director router. Works as front end router for redux react applications.
@@ -75,10 +71,6 @@
 - **react-router-route-reducers**  
   https://github.com/mrtnbroder/react-router-route-reducers  
   Add reducer to your routes and let them be composed and combined into a single state object that follows your route-structure.
-  
-- **redux-history-utils**  
-  https://github.com/kchmck/redux-history-utils  
-  Simple redux utilities for history and navigation
   
 - **redux-history-sync**  
   https://github.com/cape-io/redux-history-sync  
@@ -227,10 +219,6 @@
 - **redux-saga-first-router**  
   https://github.com/ChaosGroup/redux-saga-first-router  
   "Saga First" Router for React/Redux/Saga Projects, inspired by the best parts of redux-saga-router and redux-first-router. 
-  
-- **bind-redux-router**  
-  https://github.com/loispostula/bind-redux-react-router  
-  Tiny lib to bind redux and react-router.  The goal of this lib is to make the interaction between redux and react router as simple as possible.
   
 - **react-redux-router**  
   https://github.com/micahblu/react-redux-router  

--- a/side-effects-functions.md
+++ b/side-effects-functions.md
@@ -88,10 +88,6 @@
   https://github.com/tomasz-sodzawiczny/redux-call-effect  
   A declarative way to call action creators.
   
-- **redux-pact**  
-  https://github.com/coffeedoughnuts/redux-pact  
-  Utilities for dealing with simple promise-based side effects in action creators.
-  
 - **redux-super-thunk**  
   https://github.com/Atomic-Reactor/redux-super-thunk  
   Thunk middleware for Redux that adds the store as an argument.

--- a/side-effects-observables.md
+++ b/side-effects-observables.md
@@ -44,10 +44,6 @@
   https://github.com/cyclejs-community/redux-cycles  
   Bring functional reactive programming to Redux using Cycle.js 
   
-- **redux-rxjs**  
-  https://github.com/hwep/redux-rxjs  
-  RxJS based middleware for Redux. Compose and cancel async actions and handle promise more. 
-  
 - **redux-observable-utils**  
   https://github.com/sckoh/redux-observable-utils  
   Utilities to create redux-observable epics for fetching data

--- a/side-effects-other.md
+++ b/side-effects-other.md
@@ -72,7 +72,7 @@
   
 - **redux-haiku**  
   https://github.com/xaviervia/redux-haiku  
-  redux-haiku proposes is that any side-effect can be treated just like a DOM side-effect–that is, it can be done as the result of a state change. The state change can be identified by running a diff between the new and the old states on the segment of the state that the side-effect cares about, in the meanwhile reusing established patterns such as selectors, mapStateToProps, mapDispatchToProps, etc.
+  redux-haiku proposes is that any side-effect can be treated just like a DOM side-effect, that is, it can be done as the result of a state change. The state change can be identified by running a diff between the new and the old states on the segment of the state that the side-effect cares about, in the meanwhile reusing established patterns such as selectors, mapStateToProps, mapDispatchToProps, etc.
   
 - **redux-effex**  
   https://github.com/brentvatne/redux-effex  

--- a/store-persistence.md
+++ b/store-persistence.md
@@ -12,9 +12,8 @@
   Store enhancer that syncs (a subset) of your Redux store state to localstorage.
   
 - **redux-offline**  
-  https://github.com/jevakallio/redux-offline  
   https://github.com/redux-offline/redux-offline  
-  Persistent Redux store for Reasonaboutable™? Offline-First applications, with first-class support for optimistic UI. Use with React, React Native, or as standalone state container for any web app.
+  Persistent Redux store for Reasonaboutableâ„¢? Offline-First applications, with first-class support for optimistic UI. Use with React, React Native, or as standalone state container for any web app.
   Note: the original "jevakallio" repo has become inactive, so the repo was forked to a "redux-offline" organization.
   
 - **redux-storage**  
@@ -61,10 +60,6 @@
   https://github.com/explorigin/persistent-redux  
   Persistent-Redux is a drop-in middleware that will save your Redux state and restore it on the next page load.  Previously this tool focused on PouchDB but now it offers an adapter API to use any backend.
   
-- **redux-store-sync**  
-  https://github.com/lokhmakov/redux-store-sync  
-  Redux store sync middleware
-  
 - **redux-simple-storage-middleware**  
   https://github.com/BartWaardenburg/redux-simple-storage-middleware  
   Simple redux middleware which will store the current state tree in either session- or localstorage
@@ -92,14 +87,6 @@
 - **Redux-State-Sync**  
   https://github.com/AOHUA/redux-state-sync  
   A very light weight middleware to sync your redux state across browser tabs.
-  
-- **redux-replicate**  
-  https://github.com/loggur/redux-replicate  
-  Creates a Redux store enhancer designed to replicate actions and states. Declaratively connect application state to data sources and create efficient, scalable, and reliable software with minimal effort. 
-  
-- **redux-store-sessionstorage**  
-  https://github.com/ppallesws/redux-store-sessionstorage  
-  Store enhancer that syncs (a subset) of your Redux store state to sessionstorage. 
   
 - **record-redux**  
   https://github.com/GA-MO/record-redux  
@@ -140,14 +127,6 @@
 - **redux-localstore**  
   https://github.com/arojunior/redux-localstore  
   Subscribe Redux Store and replicate to localStorage, so users can refresh the page and keep the App state
-  
-- **redux-checkpoints**  
-  https://github.com/workemy/redux-checkpoints  
-  Save / Load functionality for Redux states. 
-  
-- **node-persistent-redux**  
-  https://github.com/Jense5/node-persistent-redux  
-  Provides a very straighforward way to write a redux store to disk. This can be useful in case you want to store a configuration, like for example with electron.
   
 - **redux-persist-to-localstorage**  
   https://github.com/purposeindustries/redux-persist-to-localstorage  

--- a/store.md
+++ b/store.md
@@ -128,10 +128,6 @@
   https://github.com/ashaffer/redux-subscribe  
   Subscribe to a path in your redux state atom.  Uses a middleware shared path strings for improved performance and dynamic subscription handling.
   
-- **redux-changes**  
-  https://github.com/sprightco/redux-changes  
-  Process changes in redux with path matching.  Uses a higher-order reducer that does comparisons, and uses a path string with a matching syntax.
-  
 - **redux-observers**  
   https://github.com/xuoe/redux-observers  
   Observe Redux state changes and dispatch actions on change.
@@ -163,10 +159,6 @@
 - **redux-subscriptions**  
   https://github.com/xaviervia/redux-subscriptions  
   Higher-level API for the Redux store.subscribe.  redux-subscriptions keeps the previous state for you and gives you the ability of running diffs in the state (using object-difference) so that you can do something when part of the state is updated, much like the React bindings for Redux work.
-  
-- **redux-add-action-listener**  
-  https://github.com/carnesen/redux-add-action-listener-enhancer  
-  A store enhancer that adds a second set of subscriptions for dispatched actions
   
 - **redux-subscriber**  
   https://github.com/ivantsov/redux-subscriber  

--- a/testing.md
+++ b/testing.md
@@ -163,10 +163,6 @@
   https://github.com/madebymany/redux-action-logging  
   Redux testing utility middleware to log actions received by a store without mocking that store.
   
-- **redux-mock-dispatcher**  
-  https://github.com/playground-xyz/redux-mock-dispatcher  
-  Utility module for ease of testing redux-thunk style action creators.
-  
 - **redux-testkit**  
   https://github.com/wix/redux-testkit  
   Use this module to easily write unit tests for redux actions, including asynchronous actions using redux-thunk middleware.

--- a/use-cases.md
+++ b/use-cases.md
@@ -99,10 +99,6 @@
   https://github.com/unbounce/flag  
   Feature flagging made easy for React and Redux
   
-- **redux-feature-flags**  
-  https://github.com/zhewison/redux-feature-flags  
-  React/Redux Feature Flags
-  
 - **react-redux-ab**  
   https://github.com/ytase/react-redux-ab  
   A simple A/B testing library that stores the active variants in a reducer for easy access accross the whole application. It is universal, as it can run on the client side, browser side or any kind of application where redux can run.
@@ -166,10 +162,6 @@
   https://github.com/josepot/react-redux-scroll  
   Scroll management library for react-redux apps.
   
-- **redux-keystroke-history**  
-  https://github.com/graftss/redux-keystroke-history  
-  Maintain keystroke history in a redux store 
-  
 - **redux-browser-geolocation**  
   https://github.com/IagoLast/redux-browser-geolocation  
   HTML5 Geolocation api for redux
@@ -190,17 +182,9 @@
   https://github.com/pcs2112/redux-responsive-component  
   A higher-order component and reducer to provide props for responsive behavior.
   
-- **redux-router-scroll-restoration**  
-  https://github.com/dimalolzet/redux-router-scroll-restoration  
-  Simple middleware for scroll restoration.
-  
 - **react-redux-dimensions**  
   https://github.com/mcabs3/react-redux-dimensions  
   A simple redux integration to collect browser dimension data with some sugar to make access to dimensions "sweeter"
-  
-- **react-redux-lock**  
-  https://github.com/alirezavalizade/react-redux-lock  
-  A simple container for creating responsive apps 
   
 - **redux-resize**  
   https://github.com/ysfzrn/redux-resize  
@@ -399,10 +383,6 @@
   https://github.com/jkomyno/redux-error-snapshot  
   Redux thunk utility that aims to ease the process of retrying last failed action.
   
-- **react-redux-internet-connection**  
-  https://github.com/alirezavalizade/react-redux-internet-connection  
-  Check internet connection from your redux's state 
-  
 - **react-native-redux-connectivity**  
   https://github.com/calvium/react-native-redux-connectivity  
   Monitor network connectivity and store the result in Redux 
@@ -479,10 +459,6 @@
   https://github.com/ecomfe/redux-optimistic-manager  
   redux-optimistic-manager is a lib aimed to simplify optimistic UI implement in redux environment. this lib uses a transaction based method to handle actual and optimistic actions, rolling back optimistic ones in a future point.
   
-- **fast-undo**  
-  https://github.com/gamb/fast-undo  
-  Efficient data structure for handling undo states.
-  
 - **redux-incremental-history**  
   https://github.com/peterkhayes/redux-incremental-history  
   Given an 'inverter' function that maps actions to their opposites, allows for undo/redo in redux-based apps.
@@ -490,10 +466,6 @@
 - **redux-deep-diff**  
   https://github.com/wwilsman/redux-deep-diff  
   Higher order reducer to deep diff redux states 
-  
-- **redux-rewind**  
-  https://github.com/Serexx/redux-rewind  
-  Redux-Rewind provides scalable, single-command rollback of an arbitrary series of normal Redux Actions, where the series must complete fully, or be cancelled entirely ('Atomicity').
   
 - **undox**  
   https://github.com/JannicBeck/undox  
@@ -553,10 +525,6 @@
 - **redux-token-auth**  
   https://github.com/smoliji/redux-token-auth  
   Actions, reducer, and sagas for managing token auth behavior
-  
-- **authoc**  
-  https://github.com/Babazon/authoc  
-  Higher order component for React Redux Router authentication and redirection 
   
 - **react-redux-permissions**  
   https://github.com/shizpi/react-redux-permissions  

--- a/utilities.md
+++ b/utilities.md
@@ -126,10 +126,6 @@
   https://github.com/ralusek/reselectie  
   Memoized selector library for any immutable data structure (such as a redux immutable store). This library serves as a smaller, faster alternative to reselect AND re-reselect.
   
-- **bo-selecta**  
-  https://github.com/hnrysmth/bo-selecta  
-  Syntactic sugar for redux selectors: `select('users').from(state).byId(userId)`
-  
 - **red-ux**  
   https://github.com/codemeasandwich/red-ux  
   Provides a genSelectState utility to improve selector caching behavior, and a shouldUpdate function for simple `shouldComponentUpdate` implementation

--- a/variations.md
+++ b/variations.md
@@ -29,10 +29,6 @@
   https://github.com/gregthebusker/replux  
   Self contained components and enhancements for Redux
   
-- **Reductor**  
-  https://github.com/mbensch/reductor  
-  Opinionated JS framework for React/Redux based applications.
-  
 - **Redux Model Utilities**  
   https://github.com/jbellsey/redux-model-utils  
   A set of model-building utilities for Redux apps.  Atomic actions and reducers, easy connection to React components, direct read-only access to the model state, subscription change notifications.
@@ -45,11 +41,6 @@
 - **redux-apis**  
   https://github.com/Download/redux-apis  
   Create class-based APIs that hide the fact that Redux is being used.
-  
-- **react-redux-provide**  
-  https://github.com/loggur/react-redux-provide  
-  https://medium.com/@timbur/react-automatic-redux-providers-and-replicators-c4e35a39f1  
-  Wrap components with a smart component and later assign providers (i.e., stores and action creators) to it.
   
 - **redux-tree**  
   https://github.com/dashed/redux-tree  
@@ -87,14 +78,6 @@
   https://github.com/nathan-rice/radical  
   Radical is a client API framework, designed to simplify the creation and maintenance of React/Redux applications. Radical allows you to model your client API and state via the composition of Actions and Namespaces.
 
-- **redux-nimble**  
-  https://github.com/bodyflex/redux-nimble  
-  A library that removes a lot of the boilerplate necessary to use redux.
-
-- **redux-direct**  
-  https://github.com/collectai/redux-direct  
-  With redux-direct you can use your action creators directly inside the reducers instead of having to define string constants for each action.
-  
 - **Tango**  
   https://github.com/Graf009/tango  
   Toolkit for building redux/react applications.  Easy to understand objects instead of crazy functional composition. Bundle groups of middleware, enhancers, and reducers together as "plugins". Dead simple Component API - use ES6 classes, bring back sane behavior, bind component functions scope to class (like old react), never write mapDispatchToProps or mapStateToProps.
@@ -107,29 +90,13 @@
   https://github.com/cerebral/redux-signals  
   The Cerebral signals running on Redux
   
-- **redux-remake**  
-  https://github.com/umidbekkarimov/redux-remake  
-  Make redux reducers more easier to define by using Flux-like features.
-  
 - **redux-observe-store-path**  
   https://github.com/d6u/redux-observe-store-path  
   Efficient and descriptive Redux React binding.  Unlike connect in react-redux, redux-observe-store-path will update tree leaf component directly, rather than passing down props at each level. This way we can skip middle level components and directly update deeply nested components.
   
-- **redux-conductor**  
-  https://github.com/alexyuly/redux-conductor  
-  Automatically conduct event traffic through Redux by reacting to actions
-  
 - **Redux Action Thunk**  
   https://github.com/ShMcK/redux-action-thunk  
   Move your actions & types into Redux middleware.  No more importing actions & types. Instead, register your actions on startup and call them by dispatching strings. Redux Action Thunk (RAT) allows you to write more modular Redux code.
-  
-- **redux-realtime-cqrs**  
-  https://github.com/latam-autos/redux-realtime-cqrs  
-  Redux Realtime CQRS is a library that lets you convert a traditional request/response rest api into a Real-time api with CQRS
-  
-- **redux-action-class-middleware**  
-  https://github.com/diosmosis/redux-action-class-middleware  
-  Redux middleware that lets you define async/sync actions as ES6 classes.
   
 - **redux-semantic-action-middleware**  
   https://github.com/diosmosis/redux-semantic-action-middleware  
@@ -195,10 +162,6 @@
 - **redux-smooth-bind-actioncreators**  
   https://github.com/dsacramone/redux-smooth-bind-actioncreators  
   Simple utility to faciliate mapping and binding action creators / states to classes.  Reduce the boilerplate of "mapStateToProps" and "mapDispatchToProps" !
-  
-- **react-redux-with-path**  
-  https://github.com/ZhengHe-MD/react-redux-with-path  
-  A customization of react-redux designed for cases that want to access sub-tree of the state
   
 - **Jumpsuit**  
   https://github.com/jumpsuit/jumpsuit  
@@ -306,10 +269,6 @@
 - **react-redux-custom-store**  
   https://github.com/emmenko/react-redux-custom-store  
   Simple wrapper around react-redux. It allows to use different nested Providers by specifying a custom store name.
-  
-- **redux-modules**  
-  https://github.com/procore/redux-modules  
-  redux-modules is a refinement on the Redux module concept with developer experience in mind. It provides An intuitive way to define actions and state transformations, and a modified Redux Provider that dynamically registers new reducers as connected components are mounted.
   
 - **react-redux-model**  
   https://github.com/jhudson8/react-redux-model  
@@ -496,10 +455,6 @@
   https://github.com/jeffnian88/redux-livequery  
   Uses RxJS to provide live queries of the Redux store to components
   
-- **react-redux-dynamic-actions**  
-  https://github.com/rusty1s/react-redux-dynamic-actions  
-  Wraps around `connect`, and allows defining dynamic actions and components based on the context of the application
-  
 - **react-redux-infuser**  
   https://github.com/jgnewman/react-redux-infuser  
   A thin layer wrapping react-redux tools to simplify creating more powerful React containers.
@@ -537,10 +492,6 @@
   https://github.com/codemeasandwich/redux-auto  
   Automatically generate Redux stories and actions from your folder and file structure, using Webpack's context.
   
-- **libertad**  
-  https://github.com/FullstackTypeScript/libertad  
-  Provides a context-free alternative to the connect function and the Provider component from react-redux, based on a declarative dependency injection API for Redux application powered by decorators, and the power of TypeScript and InversifyJS.
-
 - **redux-class**  
   https://github.com/Rewieer/redux-class  
   Bringing class-style reducer factory to your redux stack.
@@ -599,7 +550,7 @@
   
 - **selectem**  
   https://github.com/sibnerian/selectem  
-  Shorthand for react-redux’s mapStateToProps. Need some props? Just select 'em!
+  Shorthand for react-redux's mapStateToProps. Need some props? Just select 'em!
   
 - **globalProvider**  
   https://github.com/mbssantos/globalProvider  
@@ -866,10 +817,6 @@
 - **refunk**  
   https://github.com/jxnblk/refunk/  
   Simple React functional setState
-  
-- **reducere**  
-  https://github.com/DaleJefferson/reducere  
-  Redux without the actions and reducers 
   
 - **reless-js**  
   https://github.com/Alber70g/reless-js  

--- a/widgets.md
+++ b/widgets.md
@@ -23,10 +23,6 @@
   https://github.com/cchamberlain/react-redux-idle-monitor  
   Works in tandem with redux-idle-monitor to connect information about a users activity / idle state into your React components.
   
-- **duck-ahead**  
-  https://github.com/yormi/duck-ahead  
-  A simple async typeahead solution for React and Redux
-  
 - **React Redux Loading Bar**  
   https://github.com/mironov/react-redux-loading-bar  
   A simple React component that provides Loading Bar (aka Progress Bar) for long running tasks. Works out of the box with redux-promise-middleware and can be easily tweaked for other usage.
@@ -34,10 +30,6 @@
 - **react-redux-terminal**  
   https://github.com/phpingme/react-redux-terminal  
   React+Redux driven terminal component
-  
-- **semantic-react-redux**  
-  https://github.com/insilica/semantic-react-redux  
-  Just a collection of components for projects using semantic-ui, redux, and react.
   
 - **react-recorder-redux**  
   https://github.com/agrasley/react-recorder-redux  
@@ -83,25 +75,13 @@
   https://github.com/schiehll/redux-loading  
   Loading control with Redux
   
-- **react-redux-secure**  
-  https://github.com/hasangilak/react-redux-secure  
-  A package which decides on displaying components based on your rules.
-  
 - **react-redux-theme-provider**  
   https://github.com/jschr/react-redux-theme-provider  
   React helpers for theming components. Works great with inline styles or any css-in-js library.
   
-- **redux-animate**  
-  https://github.com/clari/redux-animate  
-  Synchronize animation across React components with Redux
-
 - **react-redux-loadmask**  
   https://github.com/tsaiDavid/react-redux-loadmask  
   A Redux-driven loading screen mask, with various spinner options
-  
-- **redux-menu**  
-  https://github.com/datacamp/redux-menu  
-  Package to create a React menu component, connected with your Redux state and dispatch. 
   
 - **redux-infinite-list**  
   https://github.com/KirillKayumov/redux-infinite-list  
@@ -122,10 +102,6 @@
 - **react-redux-lifecycle**  
   https://github.com/mpeyper/react-redux-lifecycle  
   A higher-order component to dispatch actions on react lifecycle methods 
-  
-- **redux-choreography**  
-  https://github.com/Setsun/redux-choreography  
-  Higher-order components to maintain animation state in Redux and coordinate your animations 
   
 - **react-permissions**  
   https://github.com/IkoroVictor/react-permissions  
@@ -165,10 +141,6 @@
 - **Repanel**  
   https://github.com/StJohn3D/repanel 
   A configurable panel framework inspired by blender.org
-  
-- **React Tab Component Redux**  
-  https://github.com/pspfolio/ReactTabComponentRedux  
-  React tab component. Handling application state with Redux.
   
 - **react-tabs-redux**  
   https://github.com/patrik-piskay/react-tabs-redux  
@@ -225,10 +197,6 @@
   https://github.com/alexghenderson/react-redux-basic-modal  
   Barebones modal framework implemented in react with redux.  You feed it a mapping of ids to React components, and when an open action is dispatched, it will display only that component.
   
-- **react-material-promise-dialog**  
-  https://github.com/nsuthar0914/react-material-promise-dialog  
-  Promise based alert and confirm dialogs using react, redux and material-ui 
-  
 - **react-redux-modal-provider**  
   https://github.com/myaskevich/react-redux-modal-provider  
   react-redux-modal-provider controls the state of your React modal components using Redux.
@@ -257,17 +225,9 @@
   https://github.com/khanghoang/redux-modal  
   A convenient way to connect your modal with a Redux store.
   
-- **Modalo**  
-  https://github.com/xclix/modalo  
-  Component, actions, and reducer for displaying a modal in React-Redux apps
-  
 - **react-redux-easy-modal**  
   https://github.com/alexander-usolcev/react-redux-easy-modal  
   Basic react-redux modal implementation (reducer, store, components and actions)
-  
-- **react-redux-promising-modals**  
-  https://github.com/tkvw/react-redux-promising-modals  
-  Adds a Modal component and withModal HOC on top of the redux-promising-modals library.
   
 - **redux-dialog**  
   https://github.com/suciuvlad/redux-dialog  
@@ -432,10 +392,6 @@
   https://github.com/pcs2112/redux-flash-message  
   Unobtrusive way to display success and Error flash messages in your single page app. 
   
-- **notifications**  
-  https://github.com/xclix/notifications  
-  Component, actions, and reducer for displaying notifications in a React-Redux app
-  
 - **redux-sweetalert**  
   https://github.com/mrstebo/redux-sweetalert  
   Actions, reducers, and component for using SweetAlert with React and Redux
@@ -447,10 +403,6 @@
 - **hot-tip**  
   https://github.com/Swrve/hot-tip  
   A stress-free redux/react tooltip solution 
-  
-- **Xync**  
-  https://github.com/xclix/xync  
-  React component for displaying notifications. Use as a plain React component or connected to a Redux store.
   
   
 #### Maps


### PR DESCRIPTION
@markerikson 
All of the removed links went to a 404 page. I manually double-checked them after my script labeled them as an issue.

Some links were just out of date (like http://redux.js.org/docs/introduction/Ecosystem.html -> https://redux.js.org/introduction/ecosystem), but for the majority, I just stripped them out.